### PR TITLE
development: OCD-641: remove NA and blank test tools

### DIFF
--- a/ocd641.sql
+++ b/ocd641.sql
@@ -1,0 +1,7 @@
+update openchpl.pending_certification_result_test_tool set deleted = true where test_tool_id = (select test_tool_id from openchpl.test_tool where name = 'N/A');
+update openchpl.certification_result_test_tool set deleted = true where test_tool_id = (select test_tool_id from openchpl.test_tool where name = 'N/A');
+update openchpl.test_tool set deleted = true where name = 'N/A';
+
+update openchpl.pending_certification_result_test_tool set deleted = true where test_tool_id = (select test_tool_id from openchpl.test_tool where name = '');
+update openchpl.certification_result_test_tool set deleted = true where test_tool_id = (select test_tool_id from openchpl.test_tool where name = '');
+update openchpl.test_tool set deleted = true where name = '';


### PR DESCRIPTION
you may want to sanity check this too. i tried it in my env after uploading an N/A test tool and it seemed fine.
